### PR TITLE
Don't install the assertion reinterpretation hook

### DIFF
--- a/behave_pytest/hook.py
+++ b/behave_pytest/hook.py
@@ -1,8 +1,6 @@
-
 import sys
 
 import py
-from _pytest.monkeypatch import monkeypatch
 
 def install_pytest_asserts():
     try:
@@ -18,12 +16,7 @@ def install_pytest_asserts():
             print('Can not use py.test asserts - no compatible python interpreter')
             return
 
-    from _pytest.assertion import reinterpret  # noqa
     from _pytest.assertion import rewrite  # noqa
-
-    m = monkeypatch()
-    m.setattr(py.builtin.builtins, 'AssertionError',
-              reinterpret.AssertionError)  # noqa
 
     hook = rewrite.AssertionRewritingHook()  # noqa
     sys.meta_path.insert(0, hook)


### PR DESCRIPTION
The assertion reinterpretation hook was removed from pytest in 3.0, so
also removing installing it from `behave_pytest` restores compatibility
with recent `pytest` releases.

Installation of the hook is removed unconditionally (even for older `pytest`
versions) as the reason it was removed was due to general fragility and
unreliability.

Fixes #2 